### PR TITLE
Fix layout id mismatch

### DIFF
--- a/app/src/main/java/com/example/cardalog/ConfirmDetailsActivity.java
+++ b/app/src/main/java/com/example/cardalog/ConfirmDetailsActivity.java
@@ -39,11 +39,11 @@ public class ConfirmDetailsActivity extends AppCompatActivity {
         Uri imageUri = Uri.parse(intent.getStringExtra("imageUri"));
 
         // Find the EditText fields in the layout
-        nameEditText = findViewById(R.id.nameEditText);
-        phoneEditText = findViewById(R.id.phoneEditText);
-        emailEditText = findViewById(R.id.emailEditText);
-        companyEditText = findViewById(R.id.companyEditText);
-        addressEditText = findViewById(R.id.addressEditText);
+        nameEditText = findViewById(R.id.name);
+        phoneEditText = findViewById(R.id.phone_number);
+        emailEditText = findViewById(R.id.email);
+        companyEditText = findViewById(R.id.business_name);
+        addressEditText = findViewById(R.id.address);
 
         // Populate EditText fields with extracted information
         nameEditText.setText(info.getName());

--- a/app/src/main/res/layout/activity_confirm_details.xml
+++ b/app/src/main/res/layout/activity_confirm_details.xml
@@ -79,13 +79,4 @@
         app:layout_constraintStart_toEndOf="@id/confirm_button"
         app:layout_constraintTop_toBottomOf="@id/job_title" />
 
-    <Button
-        android:id="@+id/cancel_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Cancel"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/confirm_button"
-        app:layout_constraintTop_toBottomOf="@id/job_title" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- fix `ConfirmDetailsActivity` to use the correct view IDs from the layout
- remove duplicate `cancel_button` definition in the confirm details layout

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687989baacc883288e64dff08247c44d