### PR TITLE
Fix grammar and remove comment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
                 android:resource="@xml/file_paths" />
         </provider>
         <activity android:name=".ScanActivity" />
-        <activity android:name=".ConfirmDetailsActivity" /> <!-- Add this line -->
+        <activity android:name=".ConfirmDetailsActivity" />
 
         <activity android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -2,7 +2,7 @@
    Sample backup rules file; uncomment and customize as necessary.
    See https://developer.android.com/guide/topics/data/autobackup
    for details.
-   Note: This file is ignored for devices older that API 31
+   Note: This file is ignored for devices older than API 31.
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>


### PR DESCRIPTION
## Summary
- fix grammar in backup_rules.xml
- remove leftover comment in AndroidManifest

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68798b4d70588328a435b57ca1a91aff