### PR TITLE
Add BusinessCardInfo unit test

### DIFF
--- a/app/src/test/java/com/example/cardalog/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/cardalog/ExampleUnitTest.kt
@@ -14,4 +14,25 @@ class ExampleUnitTest {
     fun addition_isCorrect() {
         assertEquals(4, 2 + 2)
     }
+
+    @Test
+    fun businessCardInfoStoresData() {
+        val name = "John Doe"
+        val title = "CEO"
+        val company = "ExampleCorp"
+        val phone = "555-555-5555"
+        val email = "john@example.com"
+        val website = "www.example.com"
+        val address = "123 Example St"
+
+        val info = BusinessCardInfo(name, title, company, phone, email, website, address)
+
+        assertEquals(name, info.name)
+        assertEquals(title, info.jobTitle)
+        assertEquals(company, info.businessName)
+        assertEquals(phone, info.phoneNumber)
+        assertEquals(email, info.email)
+        assertEquals(website, info.website)
+        assertEquals(address, info.address)
+    }
 }


### PR DESCRIPTION
## Summary
- add `businessCardInfoStoresData` unit test verifying `BusinessCardInfo` getters

## Testing
- `./gradlew test` *(fails: Android SDK license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68798c06dad48328bdc9e5c8ef397c49